### PR TITLE
Anchor startTime for page_0 to earliest observed request time

### DIFF
--- a/src/core/har-converter.js
+++ b/src/core/har-converter.js
@@ -164,10 +164,10 @@ export function buildWaterfallDataFromHar(harLog, format = 'har') {
         }
     }
     
-    // Default page if none exist
+    // Default page if none exist (no startedDateTime yet — set below from globalEarliestMs)
     if (Object.keys(data.pages).length === 0) {
         data.pages["page_0"] = {
-            url: "", title: "", startedDateTime: new Date().toISOString(), pageTimings: {}, requests: {}
+            url: "", title: "", pageTimings: {}, requests: {}
         };
     }
 
@@ -310,8 +310,14 @@ export function buildWaterfallDataFromHar(harLog, format = 'har') {
         }
     }
 
-    if (globalEarliestMs !== Number.MAX_SAFE_INTEGER && data.pages["page_0"] && !data.pages["page_0"].startedDateTime) {
-        data.pages["page_0"].startedDateTime = new Date(globalEarliestMs).toISOString();
+    // Anchor the synthetic page_0 to the earliest observed request time so the
+    // canvas renderer's baseMs aligns with actual request timestamps. Without this,
+    // bars render at negative offsets (maxTime=0) because the page anchor defaults
+    // to the current wall-clock time while requests may have occurred in the past.
+    if (data.pages["page_0"] && !data.pages["page_0"].startedDateTime) {
+        data.pages["page_0"].startedDateTime = globalEarliestMs !== Number.MAX_SAFE_INTEGER
+            ? new Date(globalEarliestMs).toISOString()
+            : new Date().toISOString();
     }
 
     return data;


### PR DESCRIPTION
When exporting a HAR file from tools such as Charles Proxy or BrowserStack, the pages array is empty, resulting in a waterfall chart with no bars displayed for requests.

```
"pages": [],
```

For example - 
<img width="426" height="204" alt="image" src="https://github.com/user-attachments/assets/0ab47891-198b-4c9e-8a8e-dbed555494cf" />

This change will anchor the page to the earliest observed request time.

<img width="577" height="208" alt="image" src="https://github.com/user-attachments/assets/2990cd60-7c39-464c-9736-711abe3eda43" />

